### PR TITLE
fix: handle zero SHA when creating new tags in release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -370,12 +370,75 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const { data: commits } = await github.rest.repos.compareCommits({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              base: '${{ github.event.before }}' || 'HEAD~10',
-              head: context.sha
-            });
+            // 获取用于比较的基准 commit
+            let baseRef = '${{ github.event.before }}';
+
+            // 如果 before 是全零 SHA（新创建的 tag），则尝试找到上一个 tag
+            if (!baseRef || baseRef === '0000000000000000000000000000000000000000') {
+              try {
+                // 获取所有 tags，按创建时间排序
+                const { data: tags } = await github.rest.repos.listTags({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  per_page: 10
+                });
+
+                // 找到当前 tag 之前的 tag
+                const currentTag = '${{ github.ref_name }}';
+                let foundCurrent = false;
+                for (const tag of tags) {
+                  if (tag.name === currentTag) {
+                    foundCurrent = true;
+                    continue;
+                  }
+                  if (foundCurrent) {
+                    baseRef = tag.commit.sha;
+                    console.log(`Using previous tag ${tag.name} (${baseRef}) as base`);
+                    break;
+                  }
+                }
+
+                // 如果没有找到之前的 tag，获取最近的 commits
+                if (!baseRef || baseRef === '0000000000000000000000000000000000000000') {
+                  const { data: recentCommits } = await github.rest.repos.listCommits({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    per_page: 20
+                  });
+                  if (recentCommits.length > 1) {
+                    baseRef = recentCommits[Math.min(recentCommits.length - 1, 10)].sha;
+                    console.log(`No previous tag found, using commit ${baseRef} as base`);
+                  }
+                }
+              } catch (e) {
+                console.log(`Error finding base ref: ${e.message}`);
+              }
+            }
+
+            let commits = [];
+            try {
+              const { data: compareData } = await github.rest.repos.compareCommits({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                base: baseRef,
+                head: context.sha
+              });
+              commits = compareData.commits || [];
+            } catch (e) {
+              console.log(`Error comparing commits: ${e.message}`);
+              // 如果比较失败，获取最近的 commits 作为后备方案
+              try {
+                const { data: recentCommits } = await github.rest.repos.listCommits({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  sha: context.sha,
+                  per_page: 20
+                });
+                commits = recentCommits;
+              } catch (e2) {
+                console.log(`Error fetching recent commits: ${e2.message}`);
+              }
+            }
 
             let notes = `## What's Changed in ${{ needs.prepare.outputs.version_tag }}\n\n`;
 
@@ -383,7 +446,7 @@ jobs:
             const fixes = [];
             const others = [];
 
-            for (const commit of commits.commits) {
+            for (const commit of commits) {
               const msg = commit.commit.message.split('\n')[0];
               if (msg.startsWith('feat')) {
                 features.push(`- ${msg}`);


### PR DESCRIPTION
When creating a new tag, github.event.before is all zeros (0000000...), which causes the compareCommits API to return 404. This fix:
- Detects the zero SHA condition
- Falls back to finding the previous tag as base reference
- If no previous tag exists, uses recent commits
- Adds error handling with fallback to listCommits