### PR TITLE
Fix GitHub Actions release draft status

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -510,7 +510,7 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
-          draft: true
+          draft: false
           name: "PenBridge ${{ needs.prepare.outputs.version_tag }}"
           body: ${{ steps.release_notes.outputs.notes }}
           generate_release_notes: true


### PR DESCRIPTION
将 softprops/action-gh-release 的 draft 参数从 true 改为 false， 使发布的版本自动成为 latest 而不是草稿状态。