### PR TITLE
Fix unused variable TypeScript errors

### DIFF
--- a/packages/web/src/components/ai-chat/InlineDiffPreview.tsx
+++ b/packages/web/src/components/ai-chat/InlineDiffPreview.tsx
@@ -20,7 +20,6 @@ import {
 import { cn } from "@/lib/utils";
 import type { PendingChange } from "./types";
 import { generateOptimizedDiff, generateChangeSummary } from "./tools/optimizedDiff";
-import type { DiffLine } from "./tools/optimizedDiff";
 
 interface InlineDiffPreviewProps {
   pendingChange: PendingChange;

--- a/packages/web/src/components/ai-chat/tools/optimizedDiff.ts
+++ b/packages/web/src/components/ai-chat/tools/optimizedDiff.ts
@@ -3,7 +3,7 @@
  * 避免全文扫描，减少内存消耗
  */
 
-import Diff from 'diff';
+import * as Diff from 'diff';
 
 export interface DiffLine {
   type: 'added' | 'removed' | 'unchanged' | 'separator';
@@ -158,10 +158,6 @@ export function generateOptimizedDiff(
 
   // 计算变更区域的 diff（包含上下文）
   const contextStart = Math.max(0, startLine - contextLines);
-  const contextEnd = Math.min(
-    oldLines.length,
-    oldLines.length - endLine + contextLines
-  );
 
   const oldWithContext = oldLines.slice(contextStart, oldLines.length - endLine + contextLines);
   const newWithContext = newLines.slice(contextStart, newLines.length - endLine + contextLines);

--- a/packages/web/src/components/ai-chat/tools/stringMatcher.ts
+++ b/packages/web/src/components/ai-chat/tools/stringMatcher.ts
@@ -54,7 +54,7 @@ export function normalizeWhitespace(text: string): string {
       const match = line.match(/^(\s*)(.*?)(\s*)$/);
       if (!match) return line;
 
-      const [, leading, content, trailing] = match;
+      const [, leading, content] = match;
       // 保留前导空格，标准化中间内容的空白，移除尾随空格
       return leading + content.replace(/\s+/g, ' ');
     })

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2021", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "bundler",


### PR DESCRIPTION
- Remove unused DiffLine type import in InlineDiffPreview.tsx
- Update tsconfig lib to ES2021 for replaceAll support
- Fix diff module import to use namespace import (import * as Diff)
- Remove unused contextEnd variable in optimizedDiff.ts
- Remove unused trailing variable in stringMatcher.ts