### PR TITLE
Fix infinite loop in AI content replacement tool

### DIFF
--- a/packages/web/src/components/ai-chat/tools/frontendTools.ts
+++ b/packages/web/src/components/ai-chat/tools/frontendTools.ts
@@ -497,6 +497,13 @@ export async function executeToolCalls(
       // 如果有待确认的变更
       if (result.pendingChange) {
         pendingChanges.push(result.pendingChange);
+
+        // 🔧 修复：更新 context.content 为新值，使后续工具调用基于最新内容
+        // 这解决了同一轮对话中多个 replace_content 调用时，后面的替换会覆盖前面替换的 bug
+        if (result.pendingChange.type === 'content' && result.pendingChange.newValue) {
+          context.content = result.pendingChange.newValue;
+        }
+
         results.push({
           ...toolCall,
           status: "awaiting_confirmation",


### PR DESCRIPTION
问题：当 AI 在同一轮对话中调用多个 replace_content 工具时，
所有替换都基于初始内容计算，导致后面的替换会覆盖前面的修改。

原因：executeToolCalls 函数中，每次替换后没有更新 context.content， 导致后续工具调用仍使用旧内容。

修复：在生成 pendingChange 后立即更新 context.content 为新值，
使后续工具调用基于最新内容进行匹配和替换。