### PR TITLE
Fix Linux actions author email error

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -2,7 +2,10 @@
   "name": "pen-bridge-electron",
   "version": "0.3.5",
   "description": "PenBridge - 文章管理与发布工具",
-  "author": "PenBridge Team",
+  "author": {
+    "name": "PenBridge Team",
+    "email": "penbridge@users.noreply.github.com"
+  },
   "main": "dist/main.js",
   "files": [
     "dist",


### PR DESCRIPTION
Linux electron-builder requires an email in the author field for .deb package maintainer.