### PR TITLE
Fix Electron build metadata configuration error

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -2,6 +2,7 @@
   "name": "pen-bridge-electron",
   "version": "0.3.5",
   "description": "PenBridge - 文章管理与发布工具",
+  "homepage": "https://github.com/ZeroHawkeye/PenBridge",
   "author": {
     "name": "PenBridge Team",
     "email": "penbridge@users.noreply.github.com"


### PR DESCRIPTION
The electron-builder FpmTarget requires a homepage URL when building .deb packages. Added the GitHub repository URL as the homepage.